### PR TITLE
numerous spelling, grammar and punctuation fixes

### DIFF
--- a/PettyKings_02/Assets/Prefabs/UI/Stage1UICanvas.prefab
+++ b/PettyKings_02/Assets/Prefabs/UI/Stage1UICanvas.prefab
@@ -673,7 +673,7 @@ MonoBehaviour:
   - 'Get as many stars as possible!
 
 
-    Become the best king the Picts have ever seen.!'
+    Become the best king the Picts have ever seen!'
 --- !u!114 &114157935106708640
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/1Introduction to King Uuen/Introduction.asset
+++ b/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/1Introduction to King Uuen/Introduction.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     timerLength_: 0
     type_: 0
     description_: Your village has grown large enough that some of the larger settlements
-      have taken notice
+      have taken notice.
     artwork_: {fileID: 2800000, guid: 6734019cb361acc4f932e2b75ac7cbf5, type: 3}
     btnText_:
     - Lets hope they are peaceful...

--- a/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/2StartTrading/ShouldWeStartTrading.asset
+++ b/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/2StartTrading/ShouldWeStartTrading.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 0
-    description_: What should we start trading with the nearby settlements
+    description_: What should we start trading with the nearby settlements?
     artwork_: {fileID: 2800000, guid: 6734019cb361acc4f932e2b75ac7cbf5, type: 3}
     btnText_:
     - Food

--- a/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/2StartTrading/livestock or Wheat.asset
+++ b/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/2StartTrading/livestock or Wheat.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 0
-    description_: Livestock or Wheat
+    description_: Livestock or Wheat?
     artwork_: {fileID: 2800000, guid: 0b3bb281cfea5de439e79b3a8842d14e, type: 3}
     btnText_:
     - Livestock

--- a/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/4Noblemen/KingUuenSon.asset
+++ b/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/4Noblemen/KingUuenSon.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 0
-    description_: King Uuen has requested that you help foster his third son Uurad
+    description_: King Uuen has requested that you help foster his third son Uurad.
     artwork_: {fileID: 2800000, guid: edfd2a12b565e1344b6a800098913517, type: 3}
     btnText_:
     - Nope!

--- a/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/4Noblemen/KingUuengoesnuts.asset
+++ b/PettyKings_02/Assets/Resources/Events/Diplomacy/Actions/4Noblemen/KingUuengoesnuts.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 0
-    description_: King Uuen sends a messanger back with a warning about what may happen
+    description_: King Uuen sends a messenger back with a warning about what may happen
       if we refuse again...
     artwork_: {fileID: 2800000, guid: edfd2a12b565e1344b6a800098913517, type: 3}
     btnText_:

--- a/PettyKings_02/Assets/Resources/Events/Personal War/ApologyRejected.asset
+++ b/PettyKings_02/Assets/Resources/Events/Personal War/ApologyRejected.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     timerLength_: 0
     type_: 0
     description_: King Uuen spits at your pathetic offer of an apology and roars at
-      his men to prepare for battle
+      his men to prepare for battle.
     artwork_: {fileID: 2800000, guid: bfe12017220c2cc4a84f4f8219c0f8d0, type: 3}
     btnText_:
     - Meet them in the field!

--- a/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Bad Ending/BadEnd1PersonalWar.asset
+++ b/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Bad Ending/BadEnd1PersonalWar.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     timerLength_: 0
     type_: 3
     description_: While your spearmen a top the wall manage to beat back the attackers,
-      they soon break through the gatehouse having been left undefended...
+      they soon break through the undefended gatehouse...
     artwork_: {fileID: 2800000, guid: f5932ad4811d42c4c931e0a6105c9c9e, type: 3}
     btnText_:
     - Fall back to the hall!

--- a/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Good Ending/GoodEnd1PersonalWar.asset
+++ b/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Good Ending/GoodEnd1PersonalWar.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 3
-    description_: With both the walls and the gatehouse both protected, the enemies
-      break themselves against your walls like waves against rocks!
+    description_: With both the walls and the gatehouse protected, the enemies break
+      themselves against your walls like waves against rocks!
     artwork_: {fileID: 2800000, guid: 32aef84d7936f4c4786c4ec32fc441c4, type: 3}
     btnText_:
     - 'Excellent! '

--- a/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Good Ending/GoodEnd2PersonalWar.asset
+++ b/PettyKings_02/Assets/Resources/Events/Personal War/KeepOurMenBehindTheWalls/Personal Good Ending/GoodEnd2PersonalWar.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 3
-    description_: With dozens of ment lying dead outside the fort, the King Uuen pulls
-      his troops back towards his own lands
+    description_: With dozens of men lying dead outside the fort, King Uuen pulls
+      his troops back towards his own lands.
     artwork_: {fileID: 2800000, guid: 32aef84d7936f4c4786c4ec32fc441c4, type: 3}
     btnText_:
     - Victory!

--- a/PettyKings_02/Assets/Resources/Events/Revolt War/Revolt/Defend/Dodge1.asset
+++ b/PettyKings_02/Assets/Resources/Events/Revolt War/Revolt/Defend/Dodge1.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
     name_: 
     timerLength_: 0
     type_: 3
-    description_: You try to  dodge out of the way of the warrior's swing but it cataches
+    description_: You try to  dodge out of the way of the warrior's sword but it catches
       you in the neck and you slowly bleed out.
     artwork_: {fileID: 2800000, guid: 1805a9ea0136fcc469b9768f61b29e32, type: 3}
     btnText_:


### PR DESCRIPTION
Removed full stop in tutorial that came before an exclamation point
Diplomacy\Actions\1Introduction to King Uuen\Introduction - added full stop
Diplomacy\Actions\2StartTrading\livestock or Wheat - added question mark
Diplomacy\Actions\2StartTrading\ShouldWeStartTrading - added question mark
Diplomacy\Actions\4Noblemen\KingUuengoesnuts - corrected spelling of 'messenger' from 'messanger'
Diplomacy\Actions\4Noblemen\KingUuenSon - added full stop
Personal War\ApologyRejected - added full stop
PersonalWar\KeepOurMenBehindTheWalls\PersonalBadEnding\BadEnd1PersonalWar - changed wording to make more sense
Personal War\KeepOurMenBehindTheWalls\Personal Good Ending\GoodEnd1PersonalWar - Removed 2nd mention of the word 'both' to make more sense
Personal War\KeepOurMenBehindTheWalls\Personal Good Ending\GoodEnd2PersonalWar - Changed 'ment' to 'men'
Revolt War\Revolt\Defend\Dodge1 - Changed 'swing' to 'sword'